### PR TITLE
Start returning a body iterator to the request handler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
 	"http",
 	"example"

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -5,7 +5,7 @@ use http::{
 };
 use std::fs;
 
-fn headers(request: &Request) -> Response {
+fn headers(request: &mut Request) -> Response {
     match (request.path.as_str(), &request.method) {
         ("/headers", Method::Get) => Response {
             body: fs::read("example/src/static/headers.html").expect("ON"),
@@ -18,7 +18,7 @@ fn headers(request: &Request) -> Response {
             Vec::new(),
         ),
         ("/headers", Method::Post) => {
-            let body = request.body.clone().unwrap_or_else(|| "Nothing".into());
+            let body = request.body.as_mut().unwrap().all_bytes();
             let body = String::from_utf8(body).unwrap_or_else(|_| "not utf8".to_string());
 
             let content_type = request

--- a/http/src/request/body.rs
+++ b/http/src/request/body.rs
@@ -6,4 +6,13 @@ pub struct Chunk {
 }
 
 #[allow(dead_code)]
-pub trait BodyDecoder: Iterator<Item = Result<Chunk, &'static str>> {}
+pub trait BodyDecoder: Iterator<Item = Result<Chunk, &'static str>> {
+    fn all_bytes(&mut self) -> Vec<u8> {
+        let mut res = Vec::new();
+
+        while let Some(Ok(mut chunk)) = self.next() {
+            res.append(&mut chunk.buf);
+        }
+        res
+    }
+}

--- a/http/src/request/body.rs
+++ b/http/src/request/body.rs
@@ -1,3 +1,5 @@
+use std::io::BufRead;
+
 #[allow(dead_code)]
 #[derive(Debug, PartialEq)]
 pub struct Chunk {
@@ -16,3 +18,51 @@ pub trait BodyDecoder: Iterator<Item = Result<Chunk, &'static str>> {
         res
     }
 }
+
+/// A type used for requests with a known body size, explicitly indicated by the Content-Length
+/// header.
+pub struct Body<B: BufRead> {
+    buf: B,
+    length: usize,
+    done: bool,
+}
+
+impl<B: BufRead> Body<B> {
+    pub fn new(length: usize, buf: B) -> Self {
+        Body {
+            buf,
+            length,
+            done: false,
+        }
+    }
+}
+
+/// An iterator that is supposed to be used once, as the body is a single chunk with a known
+/// size.
+impl<B: BufRead> Iterator for Body<B> {
+    type Item = Result<Chunk, &'static str>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+
+        let mut chunk = Chunk {
+            buf: vec![0; self.length],
+            extension: String::new(),
+        };
+
+        match self.buf.read_exact(&mut chunk.buf) {
+            Ok(_) => {}
+            Err(_) => {
+                self.done = true;
+                return Some(Err("Expected a body"));
+            }
+        };
+
+        self.done = true;
+        Some(Ok(chunk))
+    }
+}
+
+impl<B: BufRead> BodyDecoder for Body<B> {}

--- a/http/src/request/chunked.rs
+++ b/http/src/request/chunked.rs
@@ -1,9 +1,8 @@
-/// Chunked Transfer Decoder
-/// RFC: https://datatracker.ietf.org/doc/html/rfc9112#section-7.1
-///
 use super::body::{BodyDecoder, Chunk};
 use std::io::BufRead;
 
+/// A Chunked Transfer Decoder
+/// RFC: <https://datatracker.ietf.org/doc/html/rfc9112#section-7.1>
 pub struct ChunkedDecoder<A: BufRead> {
     buf: A,
     stopped: bool,

--- a/http/src/request/chunked.rs
+++ b/http/src/request/chunked.rs
@@ -4,14 +4,14 @@
 use super::body::{BodyDecoder, Chunk};
 use std::io::BufRead;
 
-pub struct ChunkedDecoder<'a> {
-    buf: &'a mut dyn BufRead,
+pub struct ChunkedDecoder<A: BufRead> {
+    buf: A,
     stopped: bool,
 }
 
 #[allow(dead_code)]
-impl<'a> ChunkedDecoder<'a> {
-    pub fn new(buf: &'a mut dyn BufRead) -> Self {
+impl<A: BufRead> ChunkedDecoder<A> {
+    pub fn new(buf: A) -> Self {
         ChunkedDecoder {
             buf,
             stopped: false,
@@ -19,7 +19,7 @@ impl<'a> ChunkedDecoder<'a> {
     }
 }
 
-impl<'a> Iterator for ChunkedDecoder<'a> {
+impl<A: BufRead> Iterator for ChunkedDecoder<A> {
     type Item = Result<Chunk, &'static str>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -62,6 +62,9 @@ impl<'a> Iterator for ChunkedDecoder<'a> {
             }
         };
 
+        // TODO: Instead of stopping the iterator,
+        // an empty chunk should be returned. This is because the last chunk
+        // is allowed to have an extension, which may be relevant to the handler.
         if chunk_size == 0 {
             return None;
         }
@@ -76,6 +79,7 @@ impl<'a> Iterator for ChunkedDecoder<'a> {
             }
         };
 
+        // Read CR LF
         let mut _skip = [0; 2];
         self.buf.read_exact(&mut _skip).ok()?;
 
@@ -85,7 +89,7 @@ impl<'a> Iterator for ChunkedDecoder<'a> {
         }))
     }
 }
-impl<'a> BodyDecoder for ChunkedDecoder<'a> {}
+impl<A: BufRead> BodyDecoder for ChunkedDecoder<A> {}
 
 #[cfg(test)]
 mod test {

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -1,6 +1,7 @@
 pub mod body;
 pub mod chunked;
 
+use body::{BodyDecoder, Chunk};
 use chunked::ChunkedDecoder;
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read};
@@ -18,7 +19,7 @@ pub enum HttpVersion {
 
 pub struct Request<'a> {
     pub headers: Option<HashMap<String, String>>,
-    pub body: Option<Vec<u8>>,
+    pub body: Option<Box<dyn BodyDecoder + 'a>>,
     pub path: String,
 
     #[allow(dead_code)]
@@ -104,8 +105,52 @@ impl FromStr for Method {
     }
 }
 
+struct Body<B: BufRead> {
+    buf: B,
+    length: usize,
+    done: bool,
+}
+
+impl<B: BufRead> Body<B> {
+    fn new(length: usize, buf: B) -> Self {
+        Body {
+            buf,
+            length,
+            done: false,
+        }
+    }
+}
+
+impl<B: BufRead> Iterator for Body<B> {
+    type Item = Result<Chunk, &'static str>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+
+        let mut chunk = Chunk {
+            buf: vec![0; self.length],
+            extension: String::new(),
+        };
+
+        match self.buf.read_exact(&mut chunk.buf) {
+            Ok(_) => {}
+            Err(_) => {
+                self.done = true;
+                return Some(Err("Expected a body"));
+            }
+        };
+
+        self.done = true;
+        Some(Ok(chunk))
+    }
+}
+
+impl<B: BufRead> BodyDecoder for Body<B> {}
+
 impl<'a> Request<'a> {
-    pub fn from(stream: &TcpStream) -> Result<Self, String> {
+    pub fn from(stream: &'a TcpStream) -> Result<Self, String> {
         // TODO: Support url-encoding
         let mut buf = BufReader::new(stream);
         let mut lines = buf.by_ref().lines();
@@ -142,30 +187,21 @@ impl<'a> Request<'a> {
                 Some(map)
             }
         };
-        // TODO: Handle Transfer-Encoding: Chunked
-        let body = match headers {
+
+        let body: Option<Box<dyn BodyDecoder>> = match headers {
             None => None,
             Some(ref headers) => {
                 if let Some(length) = headers.get("Content-Length") {
                     // TODO: Handle isize::MAX and a max body size.
-                    let length = length
+                    let length: usize = length
                         .parse()
                         .map_err(|_| "Content-Length is not a number")?;
-                    let mut body = vec![0; length];
-                    buf.read_exact(&mut body).map_err(|_| "Expected a body")?;
-                    Some(body)
+                    Some(Box::new(Body::new(length, buf)))
                 } else if let Some(encoding) =
                     headers.get("Transfer-Encoding").map(|h| h.to_lowercase())
                 {
-                    // TODO: body should be a buffer and it's up to `self.handler` read the chunks.
                     if encoding.as_str() == "chunked" {
-                        let mut body: Vec<u8> = Vec::new();
-                        ChunkedDecoder::new(&mut buf)
-                            .filter_map(Result::ok)
-                            .for_each(|mut c| {
-                                body.append(&mut c.buf);
-                            });
-                        Some(body)
+                        Some(Box::new(ChunkedDecoder::new(buf)))
                     } else {
                         None
                     }


### PR DESCRIPTION
# Description

Instead of consuming the chunks in the `http` module and building a single vector, return an iterator to the `handler`.

# Note
The API for handling the body will probably change in the future.